### PR TITLE
Refactor

### DIFF
--- a/rockspecs/fork-dev-1.rockspec
+++ b/rockspecs/fork-dev-1.rockspec
@@ -19,7 +19,7 @@ dependencies = {
     "waitpid >= 0.3.1",
 }
 build_dependencies = {
-    "luarocks-build-hooks >= 0.7.0",
+    "luarocks-build-hooks >= 0.8.0",
 }
 build = {
     type = "hooks",

--- a/src/syscall.c
+++ b/src/syscall.c
@@ -20,16 +20,14 @@
  *  DEALINGS IN THE SOFTWARE.
  */
 
-#include <errno.h>
-#include <signal.h>
-#include <sys/types.h>
-#include <sys/wait.h>
-#include <unistd.h>
-// lua
-#include <lauxlib.h>
-#include <lua.h>
-// external
+// depend
 #include <lua_errno.h>
+// lua
+#include <lua.h>
+// system
+#include <errno.h>
+#include <sys/types.h>
+#include <unistd.h>
 
 static int fork_lua(lua_State *L)
 {


### PR DESCRIPTION
This pull request updates build dependencies and cleans up system and Lua header includes in the `src/syscall.c` file. The main goals are to ensure compatibility with newer build tools and to organize header imports for clarity and maintainability.

Dependency update:

* Updated the `luarocks-build-hooks` build dependency version requirement from `>= 0.7.0` to `>= 0.8.0` in `rockspecs/fork-dev-1.rockspec` to ensure compatibility with newer build systems.

Code cleanup and organization:

* Reorganized and cleaned up header includes in `src/syscall.c` by grouping dependencies (Lua, system, and external headers) and removing unnecessary or redundant includes such as `signal.h`, `sys/wait.h`, and `lauxlib.h`. This improves code clarity and maintainability.